### PR TITLE
Fix issue with calculating Parasha

### DIFF
--- a/Sources/KosherSwift/HebrewCalendar/JewishCalendar.swift
+++ b/Sources/KosherSwift/HebrewCalendar/JewishCalendar.swift
@@ -114,7 +114,7 @@ public class JewishCalendar: JewishDate {
             return .none
         }
         
-        let rhDow = (jewishCalendarElapsedDays + 1) & 7
+        let rhDow = jewishCalendarElapsedDays % 7
         let day = rhDow + daysSinceStartOfJewishYear
         
         return Parsha.parshalist[yearType][Int(day / 7)]


### PR DESCRIPTION
The commits added the past week to fix off-by-one issues with Parasha calculations introduced a regression in some of the tests (specifically those that tested the Parasha in December 2023). I've fixed the issue by using the modulo operator (which is what the original KosherJava uses) instead of a bitwise AND.