### PR TITLE
Prevent infinite loop when getting Parsha on the week of October 10 2025

### DIFF
--- a/Sources/KosherSwift/HebrewCalendar/JewishCalendar.swift
+++ b/Sources/KosherSwift/HebrewCalendar/JewishCalendar.swift
@@ -129,7 +129,7 @@ public class JewishCalendar: JewishDate {
         var cal = JewishCalendar(date: nextShabbos, isInIsrael: isInIsrael)
         
         while cal.getParsha() == .none {
-            nextShabbos = gregDate.next(.saturday)
+            nextShabbos = nextShabbos.next(.saturday)
             cal = JewishCalendar(date: nextShabbos, isInIsrael: isInIsrael)
         }
         


### PR DESCRIPTION
On October 10 2025 (and potentially other weeks without a Parasha), the `getWeeklyParsha` method can get stuck in an infinite loop, since it sets `nextShabbos` to the next Saturday after `gregDate`, instead of the next Saturday after `nextShabbos`. This PR fixes the issue.